### PR TITLE
fix: align default API port and centralize frontend base URL

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+PORT=8000
+CORS_ORIGIN=http://localhost:5173
+# Add your MongoDB URI, JWT secret, email credentials, etc. in a local .env file (not committed).

--- a/backend/server.js
+++ b/backend/server.js
@@ -10,8 +10,9 @@ const app = express()
 
 //* middlewares
 app.use(express.json())
+const corsOrigin = process.env.CORS_ORIGIN || "http://localhost:5173"
 app.use(cors({
-    origin: "http://localhost:5173",
+    origin: corsOrigin,
     credentials: true
 }))
 
@@ -23,7 +24,7 @@ app.use("/uploads", express.static("uploads"))
 // Serve uploads folder
 app.use("/uploads", express.static(path.join(process.cwd(), "uploads")))
 
-const PORT = process.env.PORT || 3000
+const PORT = process.env.PORT || 8000
 
 //* server starting
 app.listen(PORT, () => {

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Backend API base URL (no trailing slash). Defaults to http://localhost:8000 if unset.
+VITE_API_URL=http://localhost:8000

--- a/frontend/src/Auth/ChangePassword.jsx
+++ b/frontend/src/Auth/ChangePassword.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Loader2, Lock, Eye, EyeOff, CheckCircle } from "lucide-react";
-import axios from "axios";
+import axiosInstance from "../utils/axiosInstance.js";
 
 const ChangePassword = () => {
 
@@ -33,9 +33,10 @@ const ChangePassword = () => {
         try {
             setIsLoading(true);
 
-            const res = await axios.post(
-                `http://localhost:8000/user/change-password/${email}`,
-                { newPassword, confirmPassword }
+            const res = await axiosInstance.post(
+                `/user/change-password/${email}`,
+                { newPassword, confirmPassword },
+                { skipAuthRedirect: true }
             );
 
             setSuccess(res.data.message);

--- a/frontend/src/Auth/ForgotPassword.jsx
+++ b/frontend/src/Auth/ForgotPassword.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import axios from "axios";
+import axiosInstance from "../utils/axiosInstance.js";
 import { Loader2, CheckCircle, Mail } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
@@ -25,9 +25,10 @@ const ForgotPassword = () => {
             setIsLoading(true);
             setError("");
 
-            const res = await axios.post(
-                "http://localhost:8000/user/forgot-password",
-                { email }
+            const res = await axiosInstance.post(
+                "/user/forgot-password",
+                { email },
+                { skipAuthRedirect: true }
             );
 
             if (res.data.success) {

--- a/frontend/src/Auth/Login.jsx
+++ b/frontend/src/Auth/Login.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { validateEmail } from "../utils/helper.js";
 import { Mail, Lock, Eye, EyeOff } from "lucide-react";
-import axios from "axios";
+import axiosInstance from "../utils/axiosInstance.js";
 import { Loader2 } from "lucide-react";
 
 const Login = () => {
@@ -31,9 +31,10 @@ const Login = () => {
             setIsLoading(true);
             setError("");
 
-            const res = await axios.post(
-                "http://localhost:8000/user/login",
-                { email, password }
+            const res = await axiosInstance.post(
+                "/user/login",
+                { email, password },
+                { skipAuthRedirect: true }
             );
 
             // console.log("Login Response:", res.data);

--- a/frontend/src/Auth/Signup.jsx
+++ b/frontend/src/Auth/Signup.jsx
@@ -48,12 +48,16 @@ const SignUp = () => {
                 profileImageUrl = imgUploadRes.imageUrl || "";
             }
 
-            const response = await axiosInstance.post("/user/register", {
-                username: fullName,
-                email,
-                password,
-                profileImageUrl: profileImageUrl
-            });
+            const response = await axiosInstance.post(
+                "/user/register",
+                {
+                    username: fullName,
+                    email,
+                    password,
+                    profileImageUrl: profileImageUrl,
+                },
+                { skipAuthRedirect: true }
+            );
 
             // localStorage.setItem("token", response.data.token);
             localStorage.setItem("token", response.data.data.token);

--- a/frontend/src/Auth/Verify.jsx
+++ b/frontend/src/Auth/Verify.jsx
@@ -1,5 +1,5 @@
-import axios from "axios";
 import React, { useEffect, useState } from "react";
+import axiosInstance from "../utils/axiosInstance.js";
 import { useNavigate, useParams } from "react-router-dom";
 import { Loader2, CheckCircle, XCircle } from "lucide-react";
 
@@ -14,10 +14,11 @@ const Verify = () => {
     useEffect(() => {
         const verifyEmail = async () => {
             try {
-                const res = await axios.post(
-                    "http://localhost:8000/user/verify",
+                const res = await axiosInstance.post(
+                    "/user/verify",
                     {},
                     {
+                        skipAuthRedirect: true,
                         headers: {
                             Authorization: `Bearer ${token}`,
                         },

--- a/frontend/src/Auth/VerifyOTP.jsx
+++ b/frontend/src/Auth/VerifyOTP.jsx
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axiosInstance from "../utils/axiosInstance.js";
 import { CheckCircle, Loader2, RotateCcw } from "lucide-react";
 import React, { useRef, useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -72,9 +72,10 @@ const VerifyOTP = () => {
             setIsLoading(true);
             setError("");
 
-            const res = await axios.post(
-                `http://localhost:8000/user/verify-otp/${email}`,
-                { otp: finalOtp }
+            const res = await axiosInstance.post(
+                `/user/verify-otp/${email}`,
+                { otp: finalOtp },
+                { skipAuthRedirect: true }
             );
 
             setSuccessMessage(res.data.message);
@@ -101,8 +102,10 @@ const VerifyOTP = () => {
     // 🔄 Resend OTP
     const resendOtp = async () => {
         try {
-            await axios.post(
-                `http://localhost:8000/user/resend-otp/${email}`
+            await axiosInstance.post(
+                `/user/resend-otp/${email}`,
+                {},
+                { skipAuthRedirect: true }
             );
             setTimer(30);
             setSuccessMessage("New OTP sent successfully!");

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -1,0 +1,3 @@
+/** Backend API origin. Override with VITE_API_URL in frontend/.env (see .env.example). */
+export const API_BASE_URL =
+    import.meta.env.VITE_API_URL?.replace(/\/$/, "") || "http://localhost:8000";

--- a/frontend/src/utils/axiosInstance.js
+++ b/frontend/src/utils/axiosInstance.js
@@ -1,7 +1,7 @@
 import axios from "axios"
-// import { BASE_URL } from "./apiPaths.js"
+import { API_BASE_URL } from "../config/api.js"
 
-const BASE_URL = "http://localhost:8000"
+const BASE_URL = API_BASE_URL
 
 const axiosInstance = axios.create({
     baseURL: BASE_URL,
@@ -34,8 +34,10 @@ axiosInstance.interceptors.response.use(
     (error) => {
         // handle common errors globally
         if (error.response) {
-            if (error.response.status === 401) {
-                // redirect to login page
+            if (
+                error.response.status === 401 &&
+                !error.config?.skipAuthRedirect
+            ) {
                 window.location.href = "/"
             } else if (error.response.status) {
                 console.log("Server Error. Please Try Again Later.")


### PR DESCRIPTION
- Default backend PORT to 8000 to match the frontend.
- Read CORS origin from CORS_ORIGIN with localhost dev default.
- Add VITE_API_URL via frontend/src/config/api.js and use it in axios.
- Route auth requests through axiosInstance with skipAuthRedirect so failed login (401) does not trigger the global redirect.
- Add frontend/.env.example and backend/.env.example for local setup.

closes #8 